### PR TITLE
SREP-1268 Add stub for dedicated-admin-operator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,4 +24,9 @@ contexts:
     services_dir: certman-operator-services
     templates_dir: certman-operator-templates
   name: certman-operator
+- data:
+    output_dir: dedicated-admin-operator-processed
+    services_dir: dedicated-admin-operator-services
+    templates_dir: dedicated-admin-operator-templates
+  name: dedicated-admin-operator
 current: hive

--- a/dedicated-admin-operator-services/dedicated-admin-operator-operator.yaml
+++ b/dedicated-admin-operator-services/dedicated-admin-operator-operator.yaml
@@ -1,0 +1,15 @@
+services:
+- hash: none
+  name: dedicated-admin-operator
+  path: /hack/olm-registry/olm-artifacts-template.yaml
+  url: https://github.com/openshift/dedicated-admin-operator
+  hash_length: 7
+  environments:
+  - name: production
+    parameters:
+      REGISTRY_IMG: quay.io/app-sre/dedicated-admin-operator
+      CHANNEL: production
+  - name: staging
+    parameters:
+      REGISTRY_IMG: quay.io/app-sre/dedicated-admin-operator
+      CHANNEL: staging

--- a/dedicated-admin-operator-services/dedicated-admin-operator-operator.yaml
+++ b/dedicated-admin-operator-services/dedicated-admin-operator-operator.yaml
@@ -1,7 +1,7 @@
 services:
 - hash: none
   name: dedicated-admin-operator
-  path: /hack/olm-registry/olm-artifacts-template.yaml
+  path: /build/templates/olm-artifacts-template.yaml.tmpl
   url: https://github.com/openshift/dedicated-admin-operator
   hash_length: 7
   environments:


### PR DESCRIPTION
Add configuration for dedicated-admin-operator.

Template path has been updated to point to the new template created by this PR: https://github.com/openshift/dedicated-admin-operator/pull/37


Note: hash is set to none since it's the initial config