### PR TITLE
Promote certman operator to production

### DIFF
--- a/certman-operator-services/certman-operator.yaml
+++ b/certman-operator-services/certman-operator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: none
+- hash: a3d5cd621d6bd698aabd21b30e8265655716a82d
   name: certman-operator
   path: /hack/olm-registry/olm-artifacts-template.yaml
   url: https://github.com/openshift/certman-operator


### PR DESCRIPTION
This commit promotes certman operator version a3d5cd621d6bd698aabd21b30e8265655716a82d to production.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>