### PR TITLE
SREP-1289 - Promote latest pagerduty-operator commit to prod

### DIFF
--- a/pagerduty-operator-services/pagerduty-operator.yaml
+++ b/pagerduty-operator-services/pagerduty-operator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: b5e7f317610026bfcc4da382605f454000c0948d
+- hash: 943e65a07390e3b9a0707b22a5245452378ef236
   name: pagerduty-operator
   path: /hack/olm-registry/olm-artifacts-template.yaml
   url: https://github.com/openshift/pagerduty-operator


### PR DESCRIPTION
This PR promotes pagerduty-operator commit  [943e65a07390e3b9a0707b22a5245452378ef236 ](https://github.com/openshift/pagerduty-operator/commit/943e65a07390e3b9a0707b22a5245452378ef236) to production. 